### PR TITLE
fix linter warning in generated code

### DIFF
--- a/lib/src/class_builder.dart
+++ b/lib/src/class_builder.dart
@@ -19,8 +19,8 @@ class ClassBuilder extends Builder {
   String buildRead() {
     var code = StringBuffer();
     code.writeln('''
-    var numOfFields = reader.readByte();
-    var fields = <int, dynamic>{
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
       for (var i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return ${cls.name}(


### PR DESCRIPTION
Tiny facelift to the generated code as per https://dart-lang.github.io/linter/lints/prefer_final_locals.html